### PR TITLE
Ensure Cargo.lock is up-to-date

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -92,10 +92,6 @@ jobs:
       with:
         components: rustfmt
 
-    # Let's see if HEAD works with a (semver) up-to-date set of dependencies.
-    - name: Update Cargo.lock
-      run: cargo update
-
     - name: Run rustfmt
       run: cargo xtask ci rustfmt
 
@@ -127,10 +123,6 @@ jobs:
       uses: taiki-e/install-action@v2
       with:
         tool: cargo-hack
-
-    # Let's see if HEAD works with a (semver) up-to-date set of dependencies.
-    - name: Update Cargo.lock
-      run: cargo update
 
     - name: Run clippy
       run: cargo xtask ci clippy --profile ${{ matrix.profile }}
@@ -171,10 +163,6 @@ jobs:
       with:
         tool: cargo-tarpaulin
 
-    # Let's see if HEAD works with a (semver) up-to-date set of dependencies.
-    - name: Update Cargo.lock
-      run: cargo update
-
     - name: Check coverage
       run: cargo xtask ci tarpaulin --profile ${{ matrix.profile }}
 
@@ -204,10 +192,6 @@ jobs:
       uses: taiki-e/install-action@v2
       with:
         tool: cargo-hack
-
-    # Let's see if HEAD works with a (semver) up-to-date set of dependencies.
-    - name: Update Cargo.lock
-      run: cargo update
 
     # FIXME: `xtask ci miri` runs `cargo clean`, deleting its own binary.
     # FIXME: This is not possible on Windows, so install it before running it.
@@ -243,10 +227,6 @@ jobs:
       with:
         tool: cargo-hack
 
-    # Let's see if HEAD works with a (semver) up-to-date set of dependencies.
-    - name: Update Cargo.lock
-      run: cargo update
-
     - name: Build documentation
       run: cargo xtask ci docs --profile ${{ matrix.profile }}
 
@@ -275,12 +255,6 @@ jobs:
       uses: taiki-e/install-action@v2
       with:
         tool: cargo-upgrades
-
-    # Let's see if HEAD works with a (semver) up-to-date set of dependencies.
-    # The Cargo.lock of library crates is not published / used by other people.
-    # TODO: If we're a binary crate, FAIL if we're using outdated dependencies.
-    - name: Update Cargo.lock
-      run: cargo update
 
     - name: Check dependencies
       run: cargo xtask ci deps

--- a/.github/workflows/validate_pr_commits.yaml
+++ b/.github/workflows/validate_pr_commits.yaml
@@ -60,11 +60,8 @@ jobs:
     - name: Run rustfmt
       run: >
         git rebase
-        --fork-point origin/${{ github.base_ref }}
-        --exec '
-        cargo update &&
-        cargo xtask ci rustfmt &&
-        git checkout Cargo.lock'
+        --fork-point 'origin/${{ github.base_ref }}'
+        --exec 'cargo xtask ci rustfmt'
 
 
   build:
@@ -97,13 +94,10 @@ jobs:
     - name: Build and test
       run: >
         git rebase
-        --fork-point origin/${{ github.base_ref }}
-        --exec '
-        cargo update &&
-        cargo xtask ci clippy --profile ${{ matrix.profile }} &&
-        cargo xtask ci test   --profile ${{ matrix.profile }} &&
-        cargo xtask ci build  --profile ${{ matrix.profile }} &&
-        git checkout Cargo.lock'
+        --fork-point 'origin/${{ github.base_ref }}'
+        --exec 'cargo xtask ci clippy --profile ${{ matrix.profile }}'
+        --exec 'cargo xtask ci test   --profile ${{ matrix.profile }}'
+        --exec 'cargo xtask ci build  --profile ${{ matrix.profile }}'
 
 
   coverage:
@@ -137,11 +131,8 @@ jobs:
     - name: Check coverage
       run: >
         git rebase
-        --fork-point origin/${{ github.base_ref }}
-        --exec '
-        cargo update &&
-        cargo xtask ci tarpaulin --profile ${{ matrix.profile }} &&
-        git checkout Cargo.lock'
+        --fork-point 'origin/${{ github.base_ref }}'
+        --exec 'cargo xtask ci tarpaulin --profile ${{ matrix.profile }}'
 
 
   miri:
@@ -174,12 +165,9 @@ jobs:
     - name: Run MIRI tests
       run: >
         git rebase
-        --fork-point origin/${{ github.base_ref }}
-        --exec '
-        cargo update &&
-        cargo install --path xtask &&
-        xtask ci miri &&
-        git checkout Cargo.lock'
+        --fork-point 'origin/${{ github.base_ref }}'
+        --exec 'cargo install --path xtask'
+        --exec 'xtask ci miri'
 
 
   docs:
@@ -209,11 +197,8 @@ jobs:
     - name: Build documentation
       run: >
         git rebase
-        --fork-point origin/${{ github.base_ref }}
-        --exec '
-        cargo update &&
-        cargo xtask ci docs --profile ${{ matrix.profile }} &&
-        git checkout Cargo.lock'
+        --fork-point 'origin/${{ github.base_ref }}'
+        --exec 'cargo xtask ci docs --profile ${{ matrix.profile }}'
 
 
   deps:
@@ -237,13 +222,8 @@ jobs:
       with:
         tool: cargo-upgrades
 
-    # The Cargo.lock of library crates is not published / used by other people.
-    # TODO: If we're a binary crate, FAIL if we're using outdated dependencies.
     - name: Check dependencies
       run: >
         git rebase
-        --fork-point origin/${{ github.base_ref }}
-        --exec '
-        cargo update &&
-        cargo xtask ci deps &&
-        git checkout Cargo.lock'
+        --fork-point 'origin/${{ github.base_ref }}'
+        --exec 'cargo xtask ci deps'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys",
 ]
@@ -272,9 +272,9 @@ checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -731,7 +731,7 @@ fn miri(args: &MiriArgs) -> [CommandLine; 3]
 fn deps() -> [CommandLine; 3]
 {
     let upgrades = vec!["cargo", "upgrades"];
-    let update = vec!["cargo", "--locked", "update", "--workspace"];
+    let update = vec!["cargo", "--locked", "update"];
     let audit = vec!["cargo", "--locked", "audit", "--deny", "warnings"];
 
     [upgrades, update, audit]
@@ -853,7 +853,7 @@ mod tests
                 "--feature-powerset", "--optional-deps"],
             &["cargo", "+nightly", "--locked", "clean"],
             &["cargo", "upgrades"],
-            &["cargo", "--locked", "update", "--workspace"],
+            &["cargo", "--locked", "update"],
             &["cargo", "--locked", "audit", "--deny", "warnings"],
         ]; "default tasklist")]
     #[test_case(


### PR DESCRIPTION
`Cargo.lock` must always be up-to-date if this was a binary crate,
because users may try to install it via `cargo install` instead of
`cargo install --locked`.

`lazy_errors` is not a binary crate. Cargo does not publish `Cargo.lock`
to crates.io. When users add a dependency on `lazy_errors`, Cargo will
try to use recent versions of (transitive) dependencies, regardless
of what we put in our `Cargo.lock`. Cargo may also fall back to older
semver-compatible versions, depending on requirements of other
dependencies of the user. Thus, `lazy_errors` must support
using recent dependency versions (i.e. after running `cargo update`),
but having an outdated `Cargo.lock` doesn't matter to the user,
so we have allowed it to be outdated so far.

However, if `Cargo.lock` is outdated and the software is only tested
after `cargo update` in CI, we may introduce features that actually
don't work in local checkouts without updating `Cargo.lock` before.
Having to run `cargo update` locally must not be a precondition
to be able to build/test this software.Thus, we have two options:
Either run all steps of the CI pipeline both with and without updating
`Cargo.lock` before, effectively doubling CI time/resource usage.
Or simply treat binary and library projects the same and require
`Cargo.lock` to be up-to-date in all cases.

Requiring `Cargo.lock` to be up-to-date will make the (scheduled) build
fail more often. However, this can be fixed very quickly and does not
mandate publishing a release of `lazy_errors` because it's a library.