### PR TITLE
Add StashedResult::ok()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file documents all changes affecting the [semver] version of this project.
 ## New in this release
 
 - Add crate `keywords` and `categories`
+- Add StashedResult::ok()
 
 ## [`v0.2.0`] (2024-06-07)
 


### PR DESCRIPTION
Returns `Some(t)` if `self` is `Ok(t)`, `None` otherwise.

This method is useful to discard the `&mut` borrowing of the `ErrorStash`/`StashWithErrors` that was passed as parameter to `or_stash`. You may need to do this if you have multiple `or_stash` statements and want to extract the `Ok(T)` result from them later.