### PR TITLE
Use `core::error::Error` by default instead of `std::error::Error`

### DIFF
--- a/.github/workflows/not_dependabot.yaml
+++ b/.github/workflows/not_dependabot.yaml
@@ -151,7 +151,7 @@ jobs:
 
     strategy:
       matrix:
-        rust-version: [ "1.77", "1.69", "1.66", "1.64", "1.61" ]
+        rust-version: [ "1.81", "1.77", "1.69", "1.66", "1.64", "1.61" ]
         system: [ ubuntu-latest, windows-latest, macos-latest ]
         branch: ${{ fromJson(needs.init.outputs.branches) }}
         profile: [ dev, release ]

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -264,7 +264,7 @@ jobs:
 
     strategy:
       matrix:
-        rust-version: [ "1.77", "1.61" ]
+        rust-version: [ "1.81", "1.61" ]
         system: [ ubuntu-latest, windows-latest, macos-latest ]
         branch: ${{ fromJson(needs.init.outputs.branches) }}
         profile: [ dev, release ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ This file documents all changes affecting the [semver] version of this project.
 
 ## New in this release
 
+### Breaking Changes
+
+- Uses `core::error::Error` by default now (instead of `std::error::Error`)
+  - Adds the `rust-v1.81` feature (enabled by default)
+    because `core::error::Error` is stable only since Rust v1.81
+  - Disables the `std` feature by default
+    because it is not needed anymore since Rust v1.81
+  - This is NOT a breaking change if you're using Rust v1.81 or later
+  - You also DON'T need to change your code if you've been using `no_std`
+    (i.e. types exported via the `surrogate_error_trait` module),
+    regardless of the Rust toolchain version you're using
+  - If you're using a Rust toolchain older than v1.81, please disable
+    the `rust-v1.81` feature and either enable the `std` feature or use
+    types from the `surrogate_error_trait` module
+
 ## [`v0.7.0`] (2024-07-09)
 
 ### Breaking Changes

--- a/lazy_errors/Cargo.toml
+++ b/lazy_errors/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.0.0"
 
 [features]
 default = [
-  "std",
+  "rust-v1.81",
   "rust-v1.77",
   "rust-v1.69",
   "rust-v1.66",
@@ -20,6 +20,7 @@ default = [
 ]
 eyre = ["std", "dep:eyre"]
 std = []
+"rust-v1.81" = []
 "rust-v1.77" = []
 "rust-v1.69" = []
 "rust-v1.66" = []

--- a/lazy_errors/src/err.rs
+++ b/lazy_errors/src/err.rs
@@ -6,7 +6,7 @@
 /// or when your codebase is generally using the
 /// return type
 #[cfg_attr(
-    feature = "std",
+    any(feature = "rust-v1.81", feature = "std"),
     doc = r##"
 [`lazy_errors::Result`](crate::Result)
 or
@@ -15,10 +15,12 @@ or
  "##
 )]
 #[cfg_attr(
-    not(feature = "std"),
+    not(any(feature = "rust-v1.81", feature = "std")),
     doc = r##"
 [`lazy_errors::surrogate_error_trait::Result`]
-(or `lazy_errors::Result` if the `std` feature is enabled).
+(or `lazy_errors::Result` if any of
+the `rust-v1.81` or
+the `std` features is enabled).
 
  "##
 )]
@@ -28,10 +30,10 @@ or
 /// A guard clause is a typical use case for this macro:
 ///
 /// ```
-/// #[cfg(feature = "std")]
+/// #[cfg(any(feature = "rust-v1.81", feature = "std"))]
 /// use lazy_errors::{err, Result};
 ///
-/// #[cfg(not(feature = "std"))]
+/// #[cfg(not(any(feature = "rust-v1.81", feature = "std")))]
 /// use lazy_errors::{err, surrogate_error_trait::Result};
 ///
 /// fn handle_ascii(text: &str) -> Result<()>
@@ -49,6 +51,7 @@ or
 #[macro_export]
 macro_rules! err {
     ($($arg:tt)*) => {{
-        $crate::Error::from_message(std::format!($($arg)*))
+        extern crate alloc;
+        $crate::Error::from_message(alloc::format!($($arg)*))
     }};
 }

--- a/lazy_errors/src/into_eyre.rs
+++ b/lazy_errors/src/into_eyre.rs
@@ -1,4 +1,4 @@
-use alloc::fmt::Display;
+use core::fmt::Display;
 
 use crate::{
     error::{AdHocError, Error, ErrorData, StashedErrors, WrappedError},
@@ -27,7 +27,7 @@ where I: IntoEyreReport
     ///
     /// fn parse(s: &str) -> eyre::Result<i32>
     /// {
-    ///     use std::str::FromStr;
+    ///     use core::str::FromStr;
     ///     i32::from_str(s).wrap_err_with(|| format!("Not an i32: '{s}'"))
     /// }
     ///
@@ -67,7 +67,7 @@ where I: IntoEyreReport
 /// Do not implement this trait. Importing the trait is sufficient.
 /// due to blanket implementations. The trait is implemented on
 /// [`StashWithErrors`] and on
-/// `E` if `E` implements `std::error::Error + Send + Sync + 'a`.
+/// `E` if `E` implements `core::error::Error + Send + Sync + 'a`.
 pub trait IntoEyreReport
 {
     /// Lossy conversion to return some type, for example
@@ -167,7 +167,7 @@ impl<I: Display> IntoEyreReport for StashWithErrors<I>
     /// Secondly, there aren't any accessors for these errors.
     /// Thirdly, these errors are not printed when using `{:?}`,
     /// as opposed to the “regular” error causes added via `wrap_err`.
-    /// If we used `Into<Box<dyn std::error::Error + Send + Sync + 'static>>`
+    /// If we used `Into<Box<dyn core::error::Error + Send + Sync + 'static>>`
     /// and return the [`eyre::Report`] from `main`, eyre would
     /// display the error using the regular, non-pretty-printed
     /// form and we won't see the full list of errors.

--- a/lazy_errors/src/or_create_stash.rs
+++ b/lazy_errors/src/or_create_stash.rs
@@ -10,14 +10,14 @@ use crate::StashWithErrors;
 /// where `I` is the [_inner error type_](crate::Error#inner-error-type-i),
 /// typically [`prelude::Stashable`].
 #[cfg_attr(
-    feature = "std",
+    any(feature = "rust-v1.81", feature = "std"),
     doc = r##"
 
 [`prelude::Stashable`]: crate::prelude::Stashable
 "##
 )]
 #[cfg_attr(
-    not(feature = "std"),
+    not(any(feature = "rust-v1.81", feature = "std")),
     doc = r##"
 
 [`prelude::Stashable`]: crate::surrogate_error_trait::prelude::Stashable
@@ -26,7 +26,7 @@ use crate::StashWithErrors;
 pub trait OrCreateStash<F, M, T, E>
 where
     F: FnOnce() -> M,
-    M: std::fmt::Display,
+    M: core::fmt::Display,
 {
     /// If `self` is `Result::Ok(value)`, returns `Result::Ok(value)`;
     /// if `self` is `Result::Err(e)`,  returns `Result::Err(errs)`
@@ -47,10 +47,10 @@ where
     ///
     /// ```
     /// # use lazy_errors::doctest_line_num_helper as replace_line_numbers;
-    /// #[cfg(feature = "std")]
+    /// #[cfg(any(feature = "rust-v1.81", feature = "std"))]
     /// use lazy_errors::prelude::*;
     ///
-    /// #[cfg(not(feature = "std"))]
+    /// #[cfg(not(any(feature = "rust-v1.81", feature = "std")))]
     /// use lazy_errors::surrogate_error_trait::prelude::*;
     ///
     /// fn write_or_cleanup(text: &str) -> Result<(), Error>
@@ -112,7 +112,7 @@ where
 impl<F, M, T, E> OrCreateStash<F, M, T, E> for Result<T, E>
 where
     F: FnOnce() -> M,
-    M: std::fmt::Display,
+    M: core::fmt::Display,
 {
     #[track_caller]
     fn or_create_stash<I>(self, f: F) -> Result<T, StashWithErrors<I>>

--- a/lazy_errors/src/or_stash.rs
+++ b/lazy_errors/src/or_stash.rs
@@ -1,5 +1,3 @@
-use std::fmt::Display;
-
 use crate::{ErrorStash, StashWithErrors};
 
 /// Adds the [`or_stash`](Self::or_stash) method on `Result<_, E>`,
@@ -11,14 +9,14 @@ use crate::{ErrorStash, StashWithErrors};
 /// where `I` is the [_inner error type_](crate::Error#inner-error-type-i),
 /// typically [`prelude::Stashable`].
 #[cfg_attr(
-    feature = "std",
+    any(feature = "rust-v1.81", feature = "std"),
     doc = r##"
 
 [`prelude::Stashable`]: crate::prelude::Stashable
 "##
 )]
 #[cfg_attr(
-    not(feature = "std"),
+    not(any(feature = "rust-v1.81", feature = "std")),
     doc = r##"
 
 [`prelude::Stashable`]: crate::surrogate_error_trait::prelude::Stashable
@@ -45,10 +43,10 @@ pub trait OrStash<S, I, T>
     ///
     /// ```
     /// # use lazy_errors::doctest_line_num_helper as replace_line_numbers;
-    /// #[cfg(feature = "std")]
+    /// #[cfg(any(feature = "rust-v1.81", feature = "std"))]
     /// use lazy_errors::prelude::*;
     ///
-    /// #[cfg(not(feature = "std"))]
+    /// #[cfg(not(any(feature = "rust-v1.81", feature = "std")))]
     /// use lazy_errors::surrogate_error_trait::prelude::*;
     ///
     /// fn run() -> Result<(), Error>
@@ -149,7 +147,7 @@ impl<F, M, I, T, E> OrStash<ErrorStash<F, M, I>, I, T> for Result<T, E>
 where
     E: Into<I>,
     F: FnOnce() -> M,
-    M: Display,
+    M: core::fmt::Display,
 {
     #[track_caller]
     fn or_stash(self, stash: &mut ErrorStash<F, M, I>) -> StashedResult<T, I>
@@ -197,10 +195,10 @@ impl<'s, T, E> StashedResult<'s, T, E>
     ///
     /// ```
     /// # use core::str::FromStr;
-    /// #[cfg(feature = "std")]
+    /// #[cfg(any(feature = "rust-v1.81", feature = "std"))]
     /// use lazy_errors::{prelude::*, Result};
     ///
-    /// #[cfg(not(feature = "std"))]
+    /// #[cfg(not(any(feature = "rust-v1.81", feature = "std")))]
     /// use lazy_errors::surrogate_error_trait::{prelude::*, Result};
     ///
     /// fn parse_version(major: &str, minor: &str) -> Result<(u32, u32)>

--- a/lazy_errors/src/or_wrap.rs
+++ b/lazy_errors/src/or_wrap.rs
@@ -9,14 +9,14 @@ use crate::Error;
 /// where `I` is the [_inner error type_](crate::Error#inner-error-type-i),
 /// typically [`prelude::Stashable`].
 #[cfg_attr(
-    feature = "std",
+    any(feature = "rust-v1.81", feature = "std"),
     doc = r##"
 
 [`prelude::Stashable`]: crate::prelude::Stashable
 "##
 )]
 #[cfg_attr(
-    not(feature = "std"),
+    not(any(feature = "rust-v1.81", feature = "std")),
     doc = r##"
 
 [`prelude::Stashable`]: crate::surrogate_error_trait::prelude::Stashable
@@ -36,10 +36,10 @@ pub trait OrWrap<T, E>
     ///
     /// ```
     /// # use lazy_errors::doctest_line_num_helper as replace_line_numbers;
-    /// #[cfg(feature = "std")]
+    /// #[cfg(any(feature = "rust-v1.81", feature = "std"))]
     /// use lazy_errors::prelude::*;
     ///
-    /// #[cfg(not(feature = "std"))]
+    /// #[cfg(not(any(feature = "rust-v1.81", feature = "std")))]
     /// use lazy_errors::surrogate_error_trait::prelude::*;
     ///
     /// fn run(tokens: &[&str]) -> Result<(), Error>
@@ -74,13 +74,13 @@ pub trait OrWrap<T, E>
     /// [`WrappedError`]: crate::WrappedError
     /// [`or_wrap_with`]: crate::OrWrapWith::or_wrap_with
     #[cfg_attr(
-        feature = "std",
+        any(feature = "rust-v1.81", feature = "std"),
         doc = r##"
 [`prelude::Stashable`]: crate::prelude::Stashable
 "##
     )]
     #[cfg_attr(
-        not(feature = "std"),
+        not(any(feature = "rust-v1.81", feature = "std")),
         doc = r##"
 [`prelude::Stashable`]: crate::surrogate_error_trait::prelude::Stashable
 "##

--- a/lazy_errors/src/or_wrap_with.rs
+++ b/lazy_errors/src/or_wrap_with.rs
@@ -1,3 +1,5 @@
+use core::fmt::Display;
+
 use crate::Error;
 
 /// Adds the [`or_wrap_with`](Self::or_wrap_with) method on `Result<_, E>`,
@@ -9,14 +11,14 @@ use crate::Error;
 /// where `I` is the [_inner error type_](crate::Error#inner-error-type-i),
 /// typically [`prelude::Stashable`].
 #[cfg_attr(
-    feature = "std",
+    any(feature = "rust-v1.81", feature = "std"),
     doc = r##"
 
 [`prelude::Stashable`]: crate::prelude::Stashable
 "##
 )]
 #[cfg_attr(
-    not(feature = "std"),
+    not(any(feature = "rust-v1.81", feature = "std")),
     doc = r##"
 
 [`prelude::Stashable`]: crate::surrogate_error_trait::prelude::Stashable
@@ -25,7 +27,7 @@ use crate::Error;
 pub trait OrWrapWith<F, M, T, E>
 where
     F: FnOnce() -> M,
-    M: std::fmt::Display,
+    M: Display,
 {
     /// If `self` is `Result::Ok(value)`, returns `Result::Ok(value)`;
     /// if `self` is `Result::Err(e1)`, returns `Result::Err(e2)`
@@ -39,10 +41,10 @@ where
     ///
     /// ```
     /// # use lazy_errors::doctest_line_num_helper as replace_line_numbers;
-    /// #[cfg(feature = "std")]
+    /// #[cfg(any(feature = "rust-v1.81", feature = "std"))]
     /// use lazy_errors::prelude::*;
     ///
-    /// #[cfg(not(feature = "std"))]
+    /// #[cfg(not(any(feature = "rust-v1.81", feature = "std")))]
     /// use lazy_errors::surrogate_error_trait::prelude::*;
     ///
     /// fn run(tokens: &[&str]) -> Result<(), Error>
@@ -83,7 +85,7 @@ where
 impl<F, M, T, E> OrWrapWith<F, M, T, E> for Result<T, E>
 where
     F: FnOnce() -> M,
-    M: std::fmt::Display,
+    M: Display,
 {
     #[track_caller]
     fn or_wrap_with<I>(self, f: F) -> Result<T, Error<I>>

--- a/lazy_errors/src/prelude.rs
+++ b/lazy_errors/src/prelude.rs
@@ -1,5 +1,4 @@
-//! Exports traits and _aliased_ types to support the most common use-cases
-//! (when depending on `std`).
+//! Exports traits and _aliased_ types to support the most common use-cases.
 //!
 //! When using any container from `lazy_errors`, such as [`lazy_errors::Error`]
 //! or [`lazy_errors::ErrorStash`], you usually don't want to specify the
@@ -21,9 +20,14 @@
 //! the container and wrapper types from this library directly. In that case,
 //! please check out [the example in the crate root documentation][CUSTOM].
 //!
+//! If you're using a Rust version older than v1.81 _and_
+//! don't enable the `std` feature, you need to use
+//! the [`surrogate_error_trait::prelude`] instead.
+//!
 //! [`lazy_errors::Error`]: crate::Error
 //! [`lazy_errors::ErrorStash`]: crate::ErrorStash
 //! [`lazy_errors::Stashable`]: crate::Stashable
+//! [`surrogate_error_trait::prelude`]: crate::surrogate_error_trait::prelude
 //! [_inner error type_ `I`]: crate::Error#inner-error-type-i
 //! [CUSTOM]: crate#example-custom-error-types
 

--- a/lazy_errors/src/stash.rs
+++ b/lazy_errors/src/stash.rs
@@ -1,6 +1,7 @@
+use core::fmt::{self, Debug, Display};
+
 use alloc::{
     boxed::Box,
-    fmt::{Debug, Display},
     string::{String, ToString},
     vec::Vec,
 };
@@ -33,10 +34,10 @@ use crate::{
 ///
 /// ```
 /// # use lazy_errors::doctest_line_num_helper as replace_line_numbers;
-/// #[cfg(feature = "std")]
+/// #[cfg(any(feature = "rust-v1.81", feature = "std"))]
 /// use lazy_errors::prelude::*;
 ///
-/// #[cfg(not(feature = "std"))]
+/// #[cfg(not(any(feature = "rust-v1.81", feature = "std")))]
 /// use lazy_errors::surrogate_error_trait::prelude::*;
 ///
 /// let errs = ErrorStash::new(|| "Something went wrong");
@@ -124,7 +125,7 @@ where
     M: Display,
     I: Debug,
 {
-    fn fmt(&self, f: &mut alloc::fmt::Formatter<'_>) -> alloc::fmt::Result
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result
     {
         match self {
             Self::Empty(_) => write!(f, "ErrorStash(Empty)"),
@@ -143,7 +144,7 @@ where
     F: FnOnce() -> M,
     M: Display,
 {
-    fn fmt(&self, f: &mut alloc::fmt::Formatter<'_>) -> alloc::fmt::Result
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result
     {
         match self {
             Self::Empty(_) => display::<I>(f, &[]),
@@ -154,7 +155,7 @@ where
 
 impl<I> Display for StashWithErrors<I>
 {
-    fn fmt(&self, f: &mut alloc::fmt::Formatter<'_>) -> alloc::fmt::Result
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result
     {
         display(f, self.errors())
     }
@@ -225,10 +226,10 @@ where
     /// Returns `true` if the stash is empty.
     ///
     /// ```
-    /// #[cfg(feature = "std")]
+    /// #[cfg(any(feature = "rust-v1.81", feature = "std"))]
     /// use lazy_errors::prelude::*;
     ///
-    /// #[cfg(not(feature = "std"))]
+    /// #[cfg(not(any(feature = "rust-v1.81", feature = "std")))]
     /// use lazy_errors::surrogate_error_trait::prelude::*;
     ///
     /// let mut errs = ErrorStash::new(|| "Summary message");
@@ -283,10 +284,10 @@ where
     /// ```
     /// use std::collections::HashMap;
     ///
-    /// #[cfg(feature = "std")]
+    /// #[cfg(any(feature = "rust-v1.81", feature = "std"))]
     /// use lazy_errors::{prelude::*, Result};
     ///
-    /// #[cfg(not(feature = "std"))]
+    /// #[cfg(not(any(feature = "rust-v1.81", feature = "std")))]
     /// use lazy_errors::surrogate_error_trait::{prelude::*, Result};
     ///
     /// // Always parses two configs, even if the first one contains an error.
@@ -379,10 +380,10 @@ where
     ///
     /// ```
     /// # use core::str::FromStr;
-    /// #[cfg(feature = "std")]
+    /// #[cfg(any(feature = "rust-v1.81", feature = "std"))]
     /// use lazy_errors::{prelude::*, Result};
     ///
-    /// #[cfg(not(feature = "std"))]
+    /// #[cfg(not(any(feature = "rust-v1.81", feature = "std")))]
     /// use lazy_errors::surrogate_error_trait::{prelude::*, Result};
     ///
     /// fn count_numbers(nums: &[&str]) -> Result<usize>
@@ -494,10 +495,7 @@ impl<I> StashWithErrors<I>
     }
 }
 
-fn display<I>(
-    f: &mut alloc::fmt::Formatter<'_>,
-    errors: &[I],
-) -> alloc::fmt::Result
+fn display<I>(f: &mut fmt::Formatter<'_>, errors: &[I]) -> fmt::Result
 {
     let count = errors.len();
     write!(f, "Stash of {count} errors currently")
@@ -506,10 +504,12 @@ fn display<I>(
 #[cfg(test)]
 mod tests
 {
+    use core::fmt::Debug;
+
     use crate::{Error, ErrorStash};
 
     #[test]
-    #[cfg(feature = "std")]
+    #[cfg(any(feature = "rust-v1.81", feature = "std"))]
     fn stash_debug_fmt_when_empty_std()
     {
         use crate::prelude::Stashable;
@@ -523,7 +523,7 @@ mod tests
         stash_debug_fmt_when_empty::<Stashable>()
     }
 
-    fn stash_debug_fmt_when_empty<I: std::fmt::Debug>()
+    fn stash_debug_fmt_when_empty<I: Debug>()
     {
         let errs = ErrorStash::<_, _, I>::new(|| "Mock message");
 
@@ -531,7 +531,7 @@ mod tests
     }
 
     #[test]
-    #[cfg(feature = "std")]
+    #[cfg(any(feature = "rust-v1.81", feature = "std"))]
     fn stash_debug_fmt_with_errors_std()
     {
         use crate::prelude::Stashable;
@@ -565,7 +565,7 @@ mod tests
 
     fn stash_debug_fmt_with_errors<'a, I>()
     where
-        I: std::fmt::Debug,
+        I: Debug,
         Error<I>: Into<I>,
         &'a str: Into<I>,
     {

--- a/lazy_errors/src/surrogate_error_trait/prelude.rs
+++ b/lazy_errors/src/surrogate_error_trait/prelude.rs
@@ -1,12 +1,16 @@
 //! Exports traits and _aliased_ types to support the most common use-cases
-//! (when `std` and/or `core::error::Error` is _not_ available).
+//! (when neither `core::error::Error` nor `std` are available).
 //!
-//! In `#![no_std]` builds, `std::error::Error` is not available.
-//! In Rust versions before 1.81, `core::error::Error` is not available.
-//! Otherwise, consider enabling the `std` feature
-//! which makes the `lazy_errors::prelude::*` available.
+//! In Rust versions before v1.81, `core::error::Error` is not stable.
+//! In `#![no_std]` builds before Rust v1.81,
+//! `std::error::Error` is not available either.
+//! This prelude exports the surrogate error trait [`Reportable`] and
+//! type aliases that can be used in these cases.
+//! Consider using Rust v1.81 or newer, or (if that's not possible)
+//! consider enabling the `std` feature. Doing either makes
+//! the “regular” `lazy_errors::prelude::*` available.
 //! Types exported from the “regular” prelude
-//! have better intercompatibility with other crates.
+//! are compatible with other crates.
 //!
 //! When using any container from `lazy_errors`, such as [`lazy_errors::Error`]
 //! or [`lazy_errors::ErrorStash`], you usually don't want to specify the
@@ -18,12 +22,12 @@
 //!
 //! Usually, anything that you want to treat as an error can be boxed
 //! into a `lazy_errors::Stashable`.
-//! When you don't want to introduce a dependency on `std`
-//! (or when `core::error::Error` is not available),
+//! When `core::error::Error` is not available and
+//! you don't want to introduce a dependency on `std`,
 //! you need an alternative to `lazy_errors::Stashable`.
 //! [`Reportable`] is a surrogate for `std::error::Error`/`core::error::Error`.
 //! [`lazy_errors::surrogate_error_trait::Stashable`] is for
-//! [`Reportable`] what `Stashable` is for `std::error::Error`.
+//! [`Reportable`] what `lazy_errors::Stashable` is for `core::error::Error`.
 //! Also, using the `'static` bound for the trait object usually works fine.
 //! Thus, `Stashable<'static>` is the [_inner error type_ `I`] for all
 //! container type aliases exported by this prelude. We also define and export

--- a/lazy_errors/src/try2.rs
+++ b/lazy_errors/src/try2.rs
@@ -4,10 +4,10 @@
 ///
 /// ```
 /// # use core::str::FromStr;
-/// #[cfg(feature = "std")]
+/// #[cfg(any(feature = "rust-v1.81", feature = "std"))]
 /// use lazy_errors::{prelude::*, Result};
 ///
-/// #[cfg(not(feature = "std"))]
+/// #[cfg(not(any(feature = "rust-v1.81", feature = "std")))]
 /// use lazy_errors::surrogate_error_trait::{prelude::*, Result};
 ///
 /// fn parse_version(s: &str) -> Result<(u32, u32)>

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,8 +9,10 @@ publish = false
 [dependencies]
 clap = { version = "4.3.21", features = ["derive"] }
 
-# clap needs the FromStr implementations to return std::error::Error.
-# Furthermore, we need to be able to wrap errors from std::fs.
+# `clap` needs the `FromStr` implementations to return `std::error::Error`.
+# Furthermore, `xtask` needs to use several parts of `std` anyways,
+# so we could just enable the flag for `lazy_errors` as well,
+# making sure `lazy_errors` builds even on old Rust versions.
 lazy_errors = { path = "../lazy_errors", features = ["std"] }
 
 [dev-dependencies]

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -4,6 +4,8 @@
 //! Several tasks can be skipped or run individually.
 //! Please refer to the [CLI documentation](Ci) for details.
 
+use core::fmt::{self, Display};
+
 use std::env;
 
 use clap::ArgAction;
@@ -340,6 +342,8 @@ enum Profile
 #[derive(clap::ValueEnum, Debug, Copy, Clone, PartialEq, Hash, Eq)]
 enum RustVersion
 {
+    #[clap(name = "1.81")]
+    V1_81,
     #[clap(name = "1.77")]
     V1_77,
     #[clap(name = "1.69")]
@@ -441,9 +445,9 @@ impl From<&QuickArgs> for AllArgs
     }
 }
 
-impl std::fmt::Display for Profile
+impl Display for Profile
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result
     {
         match self {
             Profile::Dev => write!(f, "dev"),
@@ -745,7 +749,16 @@ fn as_feature_flags(
 {
     match rust_version {
         None => &[
-            "--group-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+            "--group-features=rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,\
+             rust-v1.64",
+            "--ignore-unknown-features",
+            "--feature-powerset",
+            "--optional-deps",
+        ],
+        Some(RustVersion::V1_81) => &[
+            "--version-range=1.81..=1.81",
+            "--exclude-features=default",
+            "--features=rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
             "--ignore-unknown-features",
             "--feature-powerset",
             "--optional-deps",
@@ -755,6 +768,7 @@ fn as_feature_flags(
             "--exclude-features=default",
             "--features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
             "--ignore-unknown-features",
+            "--exclude-features=rust-v1.81",
             "--feature-powerset",
             "--optional-deps",
         ],
@@ -763,7 +777,7 @@ fn as_feature_flags(
             "--exclude-features=default",
             "--features=rust-v1.69,rust-v1.66,rust-v1.64",
             "--ignore-unknown-features",
-            "--exclude-features=rust-v1.77",
+            "--exclude-features=rust-v1.81,rust-v1.77",
             "--feature-powerset",
             "--optional-deps",
         ],
@@ -772,7 +786,7 @@ fn as_feature_flags(
             "--exclude-features=default",
             "--features=rust-v1.66,rust-v1.64",
             "--ignore-unknown-features",
-            "--exclude-features=rust-v1.77,rust-v1.69",
+            "--exclude-features=rust-v1.81,rust-v1.77,rust-v1.69",
             "--feature-powerset",
             "--optional-deps",
         ],
@@ -781,14 +795,15 @@ fn as_feature_flags(
             "--exclude-features=default,eyre",
             "--features=rust-v1.64",
             "--ignore-unknown-features",
-            "--exclude-features=rust-v1.77,rust-v1.69,rust-v1.66",
+            "--exclude-features=rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66",
             "--feature-powerset",
             "--optional-deps",
         ],
         Some(RustVersion::V1_61) => &[
             "--version-range=1.61..=1.61",
             "--exclude-features=default,eyre",
-            "--exclude-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+            "--exclude-features=rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,\
+             rust-v1.64",
             "--feature-powerset",
             "--optional-deps",
         ],
@@ -817,14 +832,16 @@ mod tests
             &["cargo", "hack", "check",
                 "--locked", "--workspace",
                 "--all-targets",
-                "--group-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+                "--group-features=\
+                   rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
                 "--ignore-unknown-features",
                 "--feature-powerset",
                 "--optional-deps",
             ],
             &["cargo", "hack", "test",
                 "--locked", "--workspace",
-                "--group-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+                "--group-features=\
+                   rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
                 "--ignore-unknown-features",
                 "--feature-powerset",
                 "--optional-deps",
@@ -832,7 +849,8 @@ mod tests
             &["cargo", "hack", "doc",
                 "--locked", "--workspace",
                 "--no-deps",
-                "--group-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+                "--group-features=\
+                   rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
                 "--ignore-unknown-features",
                 "--feature-powerset",
                 "--optional-deps",
@@ -846,7 +864,8 @@ mod tests
             &["cargo", "hack", "clippy",
                 "--locked", "--workspace",
                 "--all-targets",
-                "--group-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+                "--group-features=\
+                   rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
                 "--ignore-unknown-features",
                 "--feature-powerset",
                 "--optional-deps",
@@ -854,7 +873,8 @@ mod tests
             ],
             &["cargo", "hack", "test",
                 "--locked", "--workspace",
-                "--group-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+                "--group-features=\
+                   rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
                 "--ignore-unknown-features",
                 "--feature-powerset",
                 "--optional-deps",
@@ -862,7 +882,8 @@ mod tests
             &["cargo", "hack", "doc",
                 "--locked", "--workspace",
                 "--no-deps",
-                "--group-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+                "--group-features=\
+                   rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
                 "--ignore-unknown-features",
                 "--feature-powerset",
                 "--optional-deps",
@@ -870,7 +891,8 @@ mod tests
             &["cargo", "hack", "build",
                 "--locked", "--workspace",
                 "--all-targets",
-                "--group-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+                "--group-features=\
+                   rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
                 "--ignore-unknown-features",
                 "--feature-powerset",
                 "--optional-deps",
@@ -884,7 +906,8 @@ mod tests
             &["cargo", "hack", "clippy",
                 "--locked", "--workspace",
                 "--all-targets",
-                "--group-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+                "--group-features=\
+                   rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
                 "--ignore-unknown-features",
                 "--feature-powerset",
                 "--optional-deps",
@@ -892,7 +915,8 @@ mod tests
             ],
             &["cargo", "hack", "test",
                 "--locked", "--workspace",
-                "--group-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+                "--group-features=\
+                   rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
                 "--ignore-unknown-features",
                 "--feature-powerset",
                 "--optional-deps",
@@ -901,7 +925,8 @@ mod tests
             &["cargo", "hack", "doc",
                 "--locked", "--workspace",
                 "--no-deps",
-                "--group-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+                "--group-features=\
+                   rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
                 "--ignore-unknown-features",
                 "--feature-powerset",
                 "--optional-deps",
@@ -910,7 +935,8 @@ mod tests
             &["cargo", "hack", "build",
                 "--locked", "--workspace",
                 "--all-targets",
-                "--group-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+                "--group-features=\
+                   rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
                 "--ignore-unknown-features",
                 "--feature-powerset",
                 "--optional-deps",
@@ -926,7 +952,8 @@ mod tests
             &["cargo", "+nightly", "--locked", "clean"],
             &["cargo", "+nightly", "hack", "miri", "test",
                 "--locked", "--workspace",
-                "--group-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+                "--group-features=\
+                   rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
                 "--ignore-unknown-features",
                 "--feature-powerset",
                 "--optional-deps",
@@ -942,14 +969,16 @@ mod tests
             &["cargo", "hack", "check",
                 "--locked", "--workspace",
                 "--all-targets",
-                "--group-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+                "--group-features=\
+                   rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
                 "--ignore-unknown-features",
                 "--feature-powerset",
                 "--optional-deps",
             ],
             &["cargo", "hack", "test",
                 "--locked", "--workspace",
-                "--group-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+                "--group-features=\
+                   rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
                 "--ignore-unknown-features",
                 "--feature-powerset",
                 "--optional-deps",
@@ -957,7 +986,8 @@ mod tests
             &["cargo", "hack", "doc",
                 "--locked", "--workspace",
                 "--no-deps",
-                "--group-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+                "--group-features=\
+                   rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
                 "--ignore-unknown-features",
                 "--feature-powerset",
                 "--optional-deps",
@@ -965,7 +995,8 @@ mod tests
             &["cargo", "hack", "build",
                 "--locked", "--workspace",
                 "--all-targets",
-                "--group-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+                "--group-features=\
+                   rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
                 "--ignore-unknown-features",
                 "--feature-powerset",
                 "--optional-deps",
@@ -974,7 +1005,8 @@ mod tests
             &["cargo", "hack", "check",
                 "--locked", "--workspace",
                 "--all-targets",
-                "--group-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+                "--group-features=\
+                   rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
                 "--ignore-unknown-features",
                 "--feature-powerset",
                 "--optional-deps",
@@ -982,7 +1014,8 @@ mod tests
             ],
             &["cargo", "hack", "test",
                 "--locked", "--workspace",
-                "--group-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+                "--group-features=\
+                   rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
                 "--ignore-unknown-features",
                 "--feature-powerset",
                 "--optional-deps",
@@ -991,7 +1024,8 @@ mod tests
             &["cargo", "hack", "doc",
                 "--locked", "--workspace",
                 "--no-deps",
-                "--group-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+                "--group-features=\
+                   rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
                 "--ignore-unknown-features",
                 "--feature-powerset",
                 "--optional-deps",
@@ -1000,7 +1034,8 @@ mod tests
             &["cargo", "hack", "build",
                 "--locked", "--workspace",
                 "--all-targets",
-                "--group-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+                "--group-features=\
+                   rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
                 "--ignore-unknown-features",
                 "--feature-powerset",
                 "--optional-deps",
@@ -1022,7 +1057,8 @@ mod tests
         &[
             &["cargo", "hack", "test",
                 "--locked", "--workspace",
-                "--group-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+                "--group-features=\
+                   rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
                 "--ignore-unknown-features",
                 "--feature-powerset",
                 "--optional-deps",
@@ -1035,7 +1071,8 @@ mod tests
             ],
             &["cargo", "hack", "test",
                 "--locked", "--workspace",
-                "--group-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+                "--group-features=\
+                   rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
                 "--ignore-unknown-features",
                 "--feature-powerset",
                 "--optional-deps",
@@ -1053,7 +1090,8 @@ mod tests
         &[
             &["cargo", "hack", "test",
                 "--locked", "--workspace",
-                "--group-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+                "--group-features=\
+                   rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
                 "--ignore-unknown-features",
                 "--feature-powerset",
                 "--optional-deps",
@@ -1066,7 +1104,8 @@ mod tests
             ],
             &["cargo", "hack", "test",
                 "--locked", "--workspace",
-                "--group-features=rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
+                "--group-features=\
+                   rust-v1.81,rust-v1.77,rust-v1.69,rust-v1.66,rust-v1.64",
                 "--ignore-unknown-features",
                 "--feature-powerset",
                 "--optional-deps",

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -16,10 +16,12 @@ mod ci;
 mod version;
 
 use core::str;
+
 use std::process::{self, ExitCode, Stdio};
 
-use ci::Ci;
 use lazy_errors::{prelude::*, Result};
+
+use ci::Ci;
 use version::Version;
 
 type CommandLine = Vec<&'static str>;
@@ -153,7 +155,7 @@ fn str_or_stash<'a, F, M>(
 ) -> &'a str
 where
     F: FnOnce() -> M,
-    M: std::fmt::Display,
+    M: core::fmt::Display,
 {
     str::from_utf8(bytes)
         .map(str::trim)

--- a/xtask/src/version.rs
+++ b/xtask/src/version.rs
@@ -1,4 +1,7 @@
-use std::{fmt::Display, str::FromStr};
+use core::{
+    fmt::{self, Display},
+    str::FromStr,
+};
 
 use lazy_errors::{prelude::*, Result};
 
@@ -127,7 +130,7 @@ impl FromStr for CustomVersion
 
 impl Display for VersionNumber
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result
     {
         match self {
             VersionNumber::MajorMinorPatch(v) => Display::fmt(v, f),
@@ -138,7 +141,7 @@ impl Display for VersionNumber
 
 impl Display for MajorMinorPatch
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result
     {
         let major = self.major;
         let minor = self.minor;
@@ -150,7 +153,7 @@ impl Display for MajorMinorPatch
 
 impl Display for CustomVersion
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result
     {
         write!(f, "{}", self.0)
     }


### PR DESCRIPTION
- Add the `rust-v1.81` feature (enabled by default)
- Disable the `std` feature by default