### PR TITLE
Deactivate automatic GitHub Release generation

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -113,11 +113,3 @@ jobs:
         cargo publish
         --package lazy_errors
         --token ${{ secrets.CRATES_IO_API_TOKEN }}
-
-    # TODO: When the changelog generation process is automated,
-    # stop attaching the entire file and instead just use the _new_ part
-    # as parameter for `body` or `body_path`.
-    - name: Create GitHub release
-      uses: softprops/action-gh-release@v2
-      with:
-        files: CHANGELOG.md


### PR DESCRIPTION
Instead, create the releases manually for now by pasting the relevant parts from `CHANGELOG.md` into the GitHub Web UI. It's not much of an effort and the release page will then contain text that's sized appropriately and not monospaced.

When the changelog generation process is automated, use the _new_ part of the changelog as parameter for `body` or `body_path` of the `softprops/action-gh-release@v2` GitHub Action.