### PR TITLE
Pass `cargo publish` token in environment variable

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -112,4 +112,5 @@ jobs:
       run: >
         cargo publish
         --package lazy_errors
-        --token ${{ secrets.CRATES_IO_API_TOKEN }}
+      env:
+        CARGO_REGISTRY_TOKEN: "${{ secrets.CRATES_IO_API_TOKEN }}"


### PR DESCRIPTION
When passing the secret via the command line, it's hidden in the log due to GitHub's Secret Redaction mechanism. However, that mechanism may fail at some point in the future. Thus, it's probably more secure to remove it entirely from the command line.