### PR TITLE
Make inner type of `Error` private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This file documents all changes affecting the [semver] version of this project.
 
 ### Breaking Changes
 
+- The value wrapped by `Error` (`Box<ErrorData>`) is now private;
+  we already had `Deref`, `AsRef`, and `From` for `ErrorData` in place
 - `push` now returns a value instead of none (i.e. `()`)
   - `StashWithErrors::push` returns a `&mut StashWithErrors` to `self`
   - `ErrorStash::push` returns a `&mut StashWithErrors` to

--- a/lazy_errors/src/error.rs
+++ b/lazy_errors/src/error.rs
@@ -9,13 +9,11 @@ pub type Location = &'static core::panic::Location<'static>;
 
 /// The primary error type to use when using this crate.
 ///
-/// [`Error`] is a [`Box`] that contains an [`ErrorData`] enum variant.
-/// The enum wraps all kinds of errors
+/// [`Error`] wraps all kinds of errors
 /// that you may want to return from functions.
-/// [`Error`] boxes that enum to avoid introducing overhead on the
-/// happy paths of functions returning `Result<_, Error>`.
+/// The error variants are represented by the [`ErrorData`] enum.
 /// You can access the [`ErrorData`] variants
-/// in [`Error`] via [`Deref`], [`AsRef`], or [`From`]:
+/// from [`Error`] via [`Deref`], [`AsRef`], or [`From`]:
 ///
 /// ```
 /// # use core::str::FromStr;
@@ -171,8 +169,10 @@ pub type Location = &'static core::panic::Location<'static>;
 [`prelude::Stashable`]: crate::surrogate_error_trait::prelude::Stashable
 "##
 )]
+// Box to avoid introducing overhead on the
+// happy paths of functions returning `Result<_, Error>`.
 #[derive(Debug)]
-pub struct Error<I>(pub Box<ErrorData<I>>);
+pub struct Error<I>(Box<ErrorData<I>>);
 
 /// Enum of all kinds of errors that you may want to return
 /// from functions when using this crate.


### PR DESCRIPTION
The value wrapped by `Error` is a `Box<ErrorData>`, we already had `Deref`, `AsRef`, and `From` for `ErrorData` in place. The fact that it's boxed should probably never have been public.